### PR TITLE
Add setting to specify driver plugins

### DIFF
--- a/src/main/java-s2/com/nordstrom/automation/selenium/SeleniumConfig.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/SeleniumConfig.java
@@ -20,7 +20,6 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.google.gson.Gson;
-import com.nordstrom.automation.selenium.AbstractSeleniumConfig.SeleniumSettings;
 import com.nordstrom.automation.settings.SettingsCore;
 
 /**

--- a/src/main/java-s3/com/nordstrom/automation/selenium/utility/RevisedCapabilityMatcher.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/utility/RevisedCapabilityMatcher.java
@@ -5,6 +5,7 @@ import static org.openqa.selenium.remote.BrowserType.SAFARI;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,8 @@ public class RevisedCapabilityMatcher extends DefaultCapabilityMatcher {
                         break;
                     }
                 }
-            } catch (IllegalArgumentException | IllegalAccessException | ClassCastException | InstantiationException e) {
+            } catch (IllegalArgumentException | IllegalAccessException | ClassCastException | InstantiationException
+                    | InvocationTargetException | NoSuchMethodException | SecurityException e) {
                 // just eat the exception
             }
         }
@@ -69,8 +71,14 @@ public class RevisedCapabilityMatcher extends DefaultCapabilityMatcher {
      *         primitive type, or {@code void}; if the class lacks a no-argument constructor; or if instantiation
      *         fails for some other reason.
      * @throws IllegalAccessException if the class or its no-argument constructor are inaccessible.
+     * @throws SecurityException if not authorized to access target class loader
+     * @throws NoSuchMethodException if no-argument constructor is absent
+     * @throws InvocationTargetException if constructor threw an exception
+     * @throws IllegalArgumentException if (non-existent) constructor arguments don't match
      */
-    private static Object newSafariValidator(Class<?> validatorClass) throws InstantiationException, IllegalAccessException {
+    private static Object newSafariValidator(Class<?> validatorClass)
+            throws InstantiationException, IllegalAccessException, IllegalArgumentException,
+            InvocationTargetException, NoSuchMethodException, SecurityException {
         if (safariValidator == null) {
             safariValidator = subclassSafariValidator(validatorClass);
         }

--- a/src/main/java-s3/com/nordstrom/automation/selenium/utility/RevisedCapabilityMatcher.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/utility/RevisedCapabilityMatcher.java
@@ -74,7 +74,7 @@ public class RevisedCapabilityMatcher extends DefaultCapabilityMatcher {
         if (safariValidator == null) {
             safariValidator = subclassSafariValidator(validatorClass);
         }
-        return safariValidator.newInstance();
+        return safariValidator.getConstructor().newInstance();
     }
     
     /**

--- a/src/main/java/com/nordstrom/automation/selenium/AbstractSeleniumConfig.java
+++ b/src/main/java/com/nordstrom/automation/selenium/AbstractSeleniumConfig.java
@@ -105,6 +105,18 @@ public abstract class AbstractSeleniumConfig extends
         TARGET_PATH("selenium.target.path", "/"),
         
         /**
+         * This setting specifies a semicolon-delimited list of fully-qualified names of local <b>Selenium Grid</b>
+         * driver plugin classes.
+         * <p>
+         * <b>NOTE</b>: Defining a value for this setting overrides the <b>ServiceLoader</b> specification defined
+         * by the associated provider configuration file (<i>com.nordstrom.automation.selenium.DriverPlugin</i>).
+         * <p>
+         * name: <b>selenium.grid.plugins</b><br>
+         * default: {@code null}
+         */
+        GRID_PLUGINS("selenium.grid.plugins", null),
+        
+        /**
          * This setting specifies whether the local <b>Selenium Grid</b> instance will be shut down at the end of the
          * test run.
          * <p>

--- a/src/main/java/com/nordstrom/automation/selenium/model/RobustElementFactory.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/RobustElementFactory.java
@@ -1,5 +1,6 @@
 package com.nordstrom.automation.selenium.model;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,8 +138,9 @@ public final class RobustElementFactory {
                     .intercept(MethodDelegation.toConstructor(wrapperClass))
                     .make()
                     .load(wrapperClass.getClassLoader())
-                    .getLoaded().newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+                    .getLoaded().getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException 
+                | InvocationTargetException | NoSuchMethodException | SecurityException e) {
             throw UncheckedThrow.throwUnchecked(e);
         }
         


### PR DESCRIPTION
This pull request adds a setting to specify local grid driver plugins. This feature enables more dynamic local grid configuration.

I also replaced uses of the deprecated `Class.newInstance` method with the recommended `Constructor.newInstance` method.