### PR TITLE
Major revisions to enable Android automation and TargetPlatform support

### DIFF
--- a/src/main/java/com/nordstrom/automation/selenium/DriverPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/DriverPlugin.java
@@ -1,11 +1,14 @@
 package com.nordstrom.automation.selenium;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.util.Map;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.nordstrom.automation.selenium.core.LocalSeleniumGrid.LocalGridServer;
 import com.nordstrom.automation.selenium.core.SeleniumGrid.GridServer;
@@ -62,8 +65,19 @@ public interface DriverPlugin {
      * @return {@link LocalGridServer} object for specified node
      * @throws IOException if an I/O error occurs
      */
-    LocalGridServer start(SeleniumConfig config, String launcherClassName, String[] dependencyContexts,
+    LocalGridServer create(SeleniumConfig config, String launcherClassName, String[] dependencyContexts,
             GridServer hubServer, final Path workingPath, final Path outputPath) throws IOException;
+    
+    /**
+     * Get constructor for this driver's {@link RemoteWebDriver} implementation.
+     * <p>
+     * <b>NOTE</b>: This is only needed for implementations that require driver-specific implementation.
+     * 
+     * @param <T> constructor type parameter
+     * @param desiredCapabilities desired capabilities for the driver
+     * @return constructor for driver-specific {@link RemoteWebDriver} implementation
+     */
+    <T extends RemoteWebDriver> Constructor<T> getRemoteWebDriverCtor(Capabilities desiredCapabilities);
     
     /**
      * Get default constructor for this driver's {@link WebElement} implementation.

--- a/src/main/java/com/nordstrom/automation/selenium/annotations/PageUrl.java
+++ b/src/main/java/com/nordstrom/automation/selenium/annotations/PageUrl.java
@@ -100,9 +100,9 @@ public @interface PageUrl {
     String port() default "{}";
     
     /**
-     * Get the page URL path.
+     * Get the page URL path or Android application activity.
      * 
-     * @return URL path
+     * @return URL path or Android application activity
      */
     String value() default "{}";
     
@@ -119,4 +119,11 @@ public @interface PageUrl {
      * @return regular expression to validate path/parameters
      */
     String pattern() default "{}";
+    
+    /**
+     * Get the Android application package.
+     * 
+     * @return application package name
+     */
+    String appPackage() default "{}";
 }

--- a/src/main/java/com/nordstrom/automation/selenium/core/JsUtility.java
+++ b/src/main/java/com/nordstrom/automation/selenium/core/JsUtility.java
@@ -224,17 +224,6 @@ public final class JsUtility {
     /**
      * Propagate the specified web driver exception, extracting encoded JavaScript exception if present
      * 
-     * @param exception web driver exception to propagate
-     * @return nothing (this method always throws the specified exception)
-     * @deprecated at 17.3.0 
-     */
-    public static RuntimeException propagate(final WebDriverException exception) {
-        throw propagate(null, exception);
-    }
-    
-    /**
-     * Propagate the specified web driver exception, extracting encoded JavaScript exception if present
-     * 
      * @param driver A handle to the currently running Selenium test window.
      * @param exception web driver exception to propagate
      * @return nothing (this method always throws the specified exception)

--- a/src/main/java/com/nordstrom/automation/selenium/core/TestBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/core/TestBase.java
@@ -1,6 +1,8 @@
 package com.nordstrom.automation.selenium.core;
 
 import java.lang.reflect.Method;
+
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 
 import com.google.common.base.Optional;
@@ -65,7 +67,9 @@ public abstract class TestBase {
      */
     public Page prepInitialPage(Page pageObj) {
         if (pageObj.getWindowHandle() == null) {
-            pageObj.setWindowHandle(pageObj.getWrappedDriver().getWindowHandle());
+            try {
+                pageObj.setWindowHandle(pageObj.getWrappedDriver().getWindowHandle());
+            } catch (UnsupportedCommandException e) { }
         }
         // required when initial page is local file
         setDriver(pageObj.getWrappedDriver());
@@ -133,7 +137,7 @@ public abstract class TestBase {
     /**
      * Activate the resolved target platform.
      * 
-     * @param driver WebDriver object
+     * @param driver WebDriver object (may be {@code null})
      */
     public void activatePlatform(WebDriver driver) {
         // by default, do nothing
@@ -193,4 +197,12 @@ public abstract class TestBase {
      * @return 'true' if specified method has {@code AfterClass} annotation; otherwise 'false'
      */
     public abstract boolean isAfterClass(Method method);
+    
+    /**
+     * Skip the test that's about to executed.
+     * 
+     * @param message message for the framework-specific test-skip exception
+     * @throws Exception framework-specific exception throw to skip the test
+     */
+    public abstract void skipTest(String message) throws Exception;
 }

--- a/src/main/java/com/nordstrom/automation/selenium/examples/AndroidPage.java
+++ b/src/main/java/com/nordstrom/automation/selenium/examples/AndroidPage.java
@@ -1,0 +1,47 @@
+package com.nordstrom.automation.selenium.examples;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.nordstrom.automation.selenium.annotations.PageUrl;
+import com.nordstrom.automation.selenium.model.Page;
+
+@PageUrl(appPackage="io.appium.android.apis", value=".app.SearchInvoke")
+public class AndroidPage extends Page {
+
+    public AndroidPage(WebDriver driver) {
+        super(driver);
+    }
+    
+    protected enum Using implements ByEnum {
+        SEARCH_QUERY(By.id("txt_query_prefill")),
+        SEARCH_BUTTON(By.id("btn_start_search")),
+        SEARCH_RESULT(By.id("android:id/search_src_text"));
+        
+        private By locator;
+        
+        Using(By locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public By locator() {
+            return locator;
+        }
+    }
+    
+    public void submitSearchQuery(String query) {
+        findElement(Using.SEARCH_QUERY).sendKeys(query);
+        findElement(Using.SEARCH_BUTTON).click();
+    }
+    
+    public String getSearchResult() {
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        WebElement searchResult = wait.until(ExpectedConditions.visibilityOfElementLocated(Using.SEARCH_RESULT.locator));
+        return searchResult.getText();
+    }
+    
+}

--- a/src/main/java/com/nordstrom/automation/selenium/examples/JUnitTargetRoot.java
+++ b/src/main/java/com/nordstrom/automation/selenium/examples/JUnitTargetRoot.java
@@ -1,0 +1,14 @@
+package com.nordstrom.automation.selenium.examples;
+
+import org.junit.BeforeClass;
+
+import com.nordstrom.automation.selenium.junit.JUnitTargetBase;
+
+public class JUnitTargetRoot extends JUnitTargetBase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        ExamplePage.setHubAsTarget();
+    }
+
+}

--- a/src/main/java/com/nordstrom/automation/selenium/examples/QuickStart.java
+++ b/src/main/java/com/nordstrom/automation/selenium/examples/QuickStart.java
@@ -20,7 +20,7 @@ import com.nordstrom.automation.selenium.AbstractSeleniumConfig.SeleniumSettings
  * <b>INTRODUCTION</b>
  * <p>
  * <b>Selenium Foundation</b> is an automation framework designed to extend and enhance the capabilities provided
- * by <b>Selenium WebDriver</b>. Support is provided for both <b>Selenium 2</b> and <b>Selenium 3</b>.
+ * by <b>Selenium WebDriver</b>.
  * <p>
  * This <b>QuickStart</b> class provides a fully-functional example of a test class built around <b>Selenium
  * Foundation</b>, <b>TestNG Foundation</b>, and the <b>Settings API</b>. It demonstrates how to set up required 

--- a/src/main/java/com/nordstrom/automation/selenium/examples/TestNgTargetRoot.java
+++ b/src/main/java/com/nordstrom/automation/selenium/examples/TestNgTargetRoot.java
@@ -1,0 +1,14 @@
+package com.nordstrom.automation.selenium.examples;
+
+import org.testng.annotations.BeforeClass;
+
+import com.nordstrom.automation.selenium.support.TestNgTargetBase;
+
+public class TestNgTargetRoot extends TestNgTargetBase {
+    
+    @BeforeClass
+    public void beforeClass() {
+        ExamplePage.setHubAsTarget();
+    }
+
+}

--- a/src/main/java/com/nordstrom/automation/selenium/junit/JUnitBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/junit/JUnitBase.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.nordstrom.automation.junit.AtomIdentity;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -118,6 +119,15 @@ public abstract class JUnitBase extends TestBase implements ArtifactParams {
         return null != method.getAnnotation(AfterClass.class);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>NOTE</b>: This method throws an {@link AssumptionViolatedException} with the specified message.
+     */
+    public void skipTest(final String message) throws Exception {
+        throw new AssumptionViolatedException(message);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/nordstrom/automation/selenium/junit/JUnitPlatformBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/junit/JUnitPlatformBase.java
@@ -34,7 +34,8 @@ public abstract class JUnitPlatformBase<P extends Enum<?> & PlatformEnum> extend
      */
     @Override
     public String[] getSubPath() {
-        return new String[] { getTargetPlatform().getName() };
+        P platform = getTargetPlatform();
+        return (platform != null) ? new String[] { platform.getName() } : new String[0];
     }
 
     /**
@@ -50,7 +51,7 @@ public abstract class JUnitPlatformBase<P extends Enum<?> & PlatformEnum> extend
      */
     @Override
     public void activatePlatform(WebDriver driver) {
-        P platform = targetPlatformRule.getPlatform();
+        P platform = getTargetPlatform();
         if (platform != null) {
             activatePlatform(driver, platform);
         }

--- a/src/main/java/com/nordstrom/automation/selenium/junit/JUnitTargetBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/junit/JUnitTargetBase.java
@@ -1,0 +1,16 @@
+package com.nordstrom.automation.selenium.junit;
+
+import com.nordstrom.automation.selenium.platform.TargetType;
+
+public class JUnitTargetBase extends JUnitPlatformBase<TargetType> {
+
+    public JUnitTargetBase() {
+        super(TargetType.class);
+    }
+
+    @Override
+    public TargetType getDefaultPlatform() {
+        return TargetType.SUPPORT;
+    }
+
+}

--- a/src/main/java/com/nordstrom/automation/selenium/listeners/PlatformInterceptor.java
+++ b/src/main/java/com/nordstrom/automation/selenium/listeners/PlatformInterceptor.java
@@ -29,7 +29,7 @@ public class PlatformInterceptor implements IMethodInterceptor {
    /**
      * Assemble a list of methods that support the current target platform
      *
-     * @param methods list of methods that are about the be run
+     * @param methods list of methods that are about to be run
      * @param context test context
      */
     @Override

--- a/src/main/java/com/nordstrom/automation/selenium/model/ContainerMethodInterceptor.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/ContainerMethodInterceptor.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Callable;
 import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -112,7 +113,10 @@ public enum ContainerMethodInterceptor {
             
             Class<?> returnType = method.getReturnType();
             Page parentPage = container.getParentPage();
-            Set<String> initialHandles = driver.getWindowHandles();
+            Set<String> initialHandles = null;
+            try {
+                initialHandles = driver.getWindowHandles();
+            } catch (UnsupportedCommandException e) { }
             
             boolean returnsContainer = ComponentContainer.class.isAssignableFrom(returnType);
             boolean returnsPage = Page.class.isAssignableFrom(returnType) && !Frame.class.isAssignableFrom(returnType);
@@ -157,9 +161,11 @@ public enum ContainerMethodInterceptor {
                         newPage.setSpawningPage(parentPage);
                         reference = null;
                     } else {
-                        newHandle = driver.getWindowHandle();
                         container.setVacated(
                                 new VacationStackTrace(method, "This page object no longer owns its target window."));
+                        try {
+                            newHandle = driver.getWindowHandle();
+                        } catch (UnsupportedCommandException e) { }
                     }
                 }
                 

--- a/src/main/java/com/nordstrom/automation/selenium/model/Page.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/Page.java
@@ -87,7 +87,9 @@ public class Page extends ComponentContainer {
      */
     @Override
     protected SearchContext switchToContext() {
-        driver.switchTo().window(windowHandle);
+        if (windowHandle != null) {
+            driver.switchTo().window(windowHandle);
+        }
         return this;
     }
     
@@ -174,7 +176,7 @@ public class Page extends ComponentContainer {
             throw new InitialPageNotSpecifiedException();
         }
         
-        driver.get(url);
+        getUrl(url, driver);
         return newPage((Class<T>) initialPage.value(), driver);
     }
     

--- a/src/main/java/com/nordstrom/automation/selenium/model/RobustElementFactory.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/RobustElementFactory.java
@@ -125,7 +125,7 @@ public final class RobustElementFactory {
                 .subclass(refClass)
                 .name(refClass.getPackage().getName() + ".Robust" + refClass.getSimpleName());
 
-        for (DriverPlugin driverPlugin : ServiceLoader.loadInstalled(DriverPlugin.class)) {
+        for (DriverPlugin driverPlugin : ServiceLoader.load(DriverPlugin.class)) {
             Implementation ctorImpl = driverPlugin.getWebElementCtor(driver, refClass);
             if (ctorImpl != null) {
                 builder = builder.defineConstructor(Visibility.PUBLIC).intercept(ctorImpl);

--- a/src/main/java/com/nordstrom/automation/selenium/platform/PlatformTargetable.java
+++ b/src/main/java/com/nordstrom/automation/selenium/platform/PlatformTargetable.java
@@ -23,7 +23,7 @@ public interface PlatformTargetable<P extends Enum<?> & PlatformEnum> extends Pa
     /**
      * Activate the specified target platform.
      * 
-     * @param driver WebDriver object
+     * @param driver WebDriver object (may be {@code null})
      * @param platform platform to be activated
      * @throws PlatformActivationFailedException if platform activation fails
      */

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/ChromeCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/ChromeCaps.java
@@ -31,7 +31,9 @@ public class ChromeCaps {
                     "{\"browserName\":\"chrome\"," +
                      "\"goog:chromeOptions\":{" +
                          "\"args\":[\"--disable-infobars\"]," +
-                         "\"prefs\":{\"credentials_enable_service\":false}}" +
+                         "\"prefs\":{\"credentials_enable_service\":false}}," +
+                     "\"personality\":\"chrome\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.ChromePlugin\"" +
                     "}";
     
     private static final String HEADLESS =
@@ -39,7 +41,8 @@ public class ChromeCaps {
                      "\"goog:chromeOptions\":{" +
                          "\"args\":[\"--disable-infobars\",\"--headless\",\"--disable-gpu\"]," +
                          "\"prefs\":{\"credentials_enable_service\":false}}," +
-                     "\"personality\":\"chrome.headless\"" +
+                     "\"personality\":\"chrome.headless\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.ChromePlugin\"" +
                     "}";
     
     private static final Map<String, String> PERSONALITIES;

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/EdgeCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/EdgeCaps.java
@@ -30,12 +30,18 @@ public class EdgeCaps {
                     "{\"browserName\":\"MicrosoftEdge\",\"maxInstances\":5,\"seleniumProtocol\":\"WebDriver\"}";
     
     private static final String BASELINE = 
-                    "{\"browserName\":\"MicrosoftEdge\",\"ms:edgeChromium\":true}";
+                    "{\"browserName\":\"MicrosoftEdge\"," +
+                     "\"ms:edgeChromium\":true" +
+                     "\"personality\":\"MicrosoftEdge\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.EdgePlugin\"" +
+                    "}";
     
     private static final String HEADLESS =
-                    "{\"browserName\":\"MicrosoftEdge\",\"ms:edgeChromium\":true," +
+                    "{\"browserName\":\"MicrosoftEdge\"," +
+                     "\"ms:edgeChromium\":true," +
                      "\"ms:edgeOptions\":{\"args\":[\"--headless\",\"--disable-gpu\"]}," +
-                     "\"personality\":\"MicrosoftEdge.headless\"" +
+                     "\"personality\":\"MicrosoftEdge.headless\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.EdgePlugin\"" +
                     "}";
 
     private static final Map<String, String> PERSONALITIES;

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/EspressoPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/EspressoPlugin.java
@@ -15,15 +15,20 @@ public class EspressoPlugin extends AbstractAppiumPlugin {
     }
 
     private static final String CAPABILITIES =
-            "{\"automationName\":\"Espresso\"," +
+            "{\"appium:automationName\":\"Espresso\"," +
              "\"platformName\":\"Android\"," +
              "\"maxInstances\":1}";
     
     private static final String BASELINE =
-            "{\"automationName\":\"Espresso\"," + 
-             "\"platformName\":\"Android\"}";
+            "{\"appium:automationName\":\"Espresso\"," + 
+             "\"platformName\":\"Android\"," +
+             "\"personality\":\"Espresso\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.EspressoPlugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
+    
+    private static final String DRIVER_CLASS_NAME = "io.appium.java_client.android.AndroidDriver";
     
     static {
         Map<String, String> personalities = new HashMap<>();
@@ -39,6 +44,11 @@ public class EspressoPlugin extends AbstractAppiumPlugin {
     @Override
     public Map<String, String> getPersonalities() {
         return PERSONALITIES;
+    }
+    
+    @Override
+    public String getDriverClassName() {
+        return DRIVER_CLASS_NAME;
     }
 
 }

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/FirefoxCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/FirefoxCaps.java
@@ -27,13 +27,17 @@ public class FirefoxCaps {
     
     private static final String BASELINE =
                     "{\"browserName\":\"firefox\"," +
-                     "\"marionette\":true}";
+                     "\"marionette\":true," +
+                     "\"personality\":\"firefox\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.FirefoxPlugin\"" +
+                    "}";
     
     private static final String HEADLESS =
                     "{\"browserName\":\"firefox\"," +
                      "\"marionette\":true," +
                      "\"moz:firefoxOptions\":{\"args\":[\"-headless\"]}," +
-                     "\"personality\":\"firefox.headless\"" +
+                     "\"personality\":\"firefox.headless\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.FirefoxPlugin\"" +
                     "}";
     
     private static final Map<String, String> PERSONALITIES;

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/HtmlUnitCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/HtmlUnitCaps.java
@@ -17,24 +17,36 @@ public class HtmlUnitCaps {
                     "{\"browserName\":\"htmlunit\"," +
                      "\"browserVersion\":\"chrome\"," +
                      "\"maxInstances\":5," +
-                     "\"seleniumProtocol\":\"WebDriver\"}";
+                     "\"seleniumProtocol\":\"WebDriver\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.HtmlUnitPlugin\"}";
     
-    private static final String BASELINE = "{\"browserName\":\"htmlunit\",\"browserVersion\":\"chrome\"}";
+    private static final String BASELINE = 
+                     "{\"browserName\":\"htmlunit\"," +
+                      "\"browserVersion\":\"chrome\"," +
+                      "\"personality\":\"htmlunit\"," +
+                      "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.HtmlUnitPlugin\"" +
+                     "}";
     
     private static final String CHROME = 
                     "{\"browserName\":\"htmlunit\"," +
                      "\"browserVersion\":\"chrome\"," +
-                     "\"personality\":\"htmlunit.chrome\"}";
+                     "\"personality\":\"htmlunit.chrome\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.HtmlUnitPlugin\"" +
+                    "}";
     
     private static final String FIREFOX = 
                     "{\"browserName\":\"htmlunit\"," +
                      "\"browserVersion\":\"firefox\"," +
-                     "\"personality\":\"htmlunit.firefox\"}";
+                     "\"personality\":\"htmlunit.firefox\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.HtmlUnitPlugin\"" +
+                    "}";
     
     private static final String INT_EXP = 
                     "{\"browserName\":\"htmlunit\"," +
                      "\"browserVersion\":\"ie\"," +
-                     "\"personality\":\"htmlunit.ie\"}";
+                     "\"personality\":\"htmlunit.ie\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.HtmlUnitPlugin\"" +
+                    "}";
     
     private static final Map<String, String> PERSONALITIES;
     

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/InternetExplorerCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/InternetExplorerCaps.java
@@ -24,7 +24,11 @@ public class InternetExplorerCaps {
     private static final String CAPABILITIES =
                     "{\"browserName\":\"internet explorer\",\"maxInstances\":1,\"seleniumProtocol\":\"WebDriver\"}";
     
-    private static final String BASELINE = "{\"browserName\":\"internet explorer\"}";
+    private static final String BASELINE =
+                    "{\"browserName\":\"internet explorer\"," +
+                     "\"personality\":\"internet explorer\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.InternetExplorerPlugin\"" +
+                    "}";
     
     private static final Map<String, String> PERSONALITIES;
     

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/Mac2Plugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/Mac2Plugin.java
@@ -15,15 +15,20 @@ public class Mac2Plugin extends AbstractAppiumPlugin {
     }
 
     private static final String CAPABILITIES =
-            "{\"automationName\":\"Mac2\"," +
+            "{\"appium:automationName\":\"Mac2\"," +
              "\"platformName\":\"Mac\"," +
              "\"maxInstances\":5}";
     
     private static final String BASELINE =
-            "{\"automationName\":\"Mac2\"," + 
-             "\"platformName\":\"Mac\"}";
+            "{\"appium:automationName\":\"Mac2\"," + 
+             "\"platformName\":\"Mac\"," +
+             "\"personality\":\"Mac2\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.Mac2Plugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
+    
+    private static final String DRIVER_CLASS_NAME = "io.appium.java_client.mac.Mac2Driver";
     
     static {
         Map<String, String> personalities = new HashMap<>();
@@ -39,6 +44,11 @@ public class Mac2Plugin extends AbstractAppiumPlugin {
     @Override
     public Map<String, String> getPersonalities() {
         return PERSONALITIES;
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return DRIVER_CLASS_NAME;
     }
 
 }

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/OperaCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/OperaCaps.java
@@ -26,7 +26,11 @@ public class OperaCaps {
     
     private static final String CAPABILITIES = "{\"browserName\":\"opera\",\"maxInstances\":5,\"seleniumProtocol\":\"WebDriver\"}";
     
-    private static final String BASELINE = "{\"browserName\":\"opera\"}";
+    private static final String BASELINE = 
+            "{\"browserName\":\"opera\"," +
+             "\"personality\":\"opera\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.OperaPlugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
     

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/PhantomJsCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/PhantomJsCaps.java
@@ -17,12 +17,17 @@ public class PhantomJsCaps {
     private static final String CAPABILITIES =
                     "{\"browserName\":\"phantomjs\",\"maxInstances\":5,\"seleniumProtocol\":\"WebDriver\"}";
     
-    private static final String BASELINE = "{\"browserName\":\"phantomjs\"}";
+    private static final String BASELINE =
+            "{\"browserName\":\"phantomjs\"," +
+             "\"personality\":\"phantomjs\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.PhantomJsPlugin\"" +
+            "}";
     
     private static final String LOGGING = 
             "{\"browserName\":\"phantomjs\"," +
              "\"loggingPrefs\":{\"browser\":\"WARNING\"}," +
-             "\"personality\":\"phantomjs.logging\"" +
+             "\"personality\":\"phantomjs.logging\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.PhantomJsPlugin\"" +
             "}";
     
     private static final Map<String, String> PERSONALITIES;

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/RemoteWebDriverPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/RemoteWebDriverPlugin.java
@@ -1,10 +1,13 @@
 package com.nordstrom.automation.selenium.plugins;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import org.openqa.grid.common.GridRole;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import com.google.common.collect.ObjectArrays;
 import com.nordstrom.automation.selenium.DriverPlugin;
@@ -39,17 +42,25 @@ public abstract class RemoteWebDriverPlugin implements DriverPlugin {
      * @throws IOException if an I/O error occurs
      */
     @Override
-    public LocalGridServer start(SeleniumConfig config, String launcherClassName, String[] dependencyContexts,
+    public LocalGridServer create(SeleniumConfig config, String launcherClassName, String[] dependencyContexts,
             GridServer hubServer, final Path workingPath, final Path outputPath) throws IOException {
         
         String[] combinedContexts = combineDependencyContexts(dependencyContexts, this);
         String capabilities = getCapabilities(config);
         Path nodeConfigPath = config.createNodeConfig(capabilities, hubServer.getUrl());
         String[] propertyNames = getPropertyNames();
-        return LocalSeleniumGrid.start(launcherClassName, combinedContexts, GridRole.NODE,
+        return LocalSeleniumGrid.create(launcherClassName, combinedContexts, GridRole.NODE,
                 Integer.valueOf(0), nodeConfigPath, workingPath, outputPath, propertyNames);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T extends RemoteWebDriver> Constructor<T> getRemoteWebDriverCtor(Capabilities desiredCapabilities) {
+        return null;
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/SafariCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/SafariCaps.java
@@ -23,7 +23,11 @@ public class SafariCaps {
     private static final String CAPABILITIES =
                     "{\"browserName\":\"safari\",\"maxInstances\":5,\"seleniumProtocol\":\"WebDriver\"}";
     
-    private static final String BASELINE = "{\"browserName\":\"safari\"}";
+    private static final String BASELINE = 
+                    "{\"browserName\":\"safari\"," +
+                     "\"personality\":\"safari\"," +
+                     "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.SafariPlugin\"" +
+                    "}";
     
     private static final Map<String, String> PERSONALITIES;
     

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/UiAutomator2Plugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/UiAutomator2Plugin.java
@@ -15,17 +15,22 @@ public class UiAutomator2Plugin extends AbstractAppiumPlugin {
     }
 
     private static final String CAPABILITIES =
-            "{\"automationName\":\"UiAutomator2\"," + 
+            "{\"appium:automationName\":\"UiAutomator2\"," + 
              "\"platformName\":\"Android\"," +
              "\"browserName\":\"Chrome\"," +
              "\"maxInstances\":1," + 
              "\"deviceName\":\"Android Emulator\"}";
     
     private static final String BASELINE =
-            "{\"automationName\":\"UiAutomator2\"," + 
-             "\"platformName\":\"Android\"}";
+            "{\"appium:automationName\":\"UiAutomator2\"," + 
+             "\"platformName\":\"Android\"," +
+             "\"personality\":\"UiAutomator2\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.UiAutomator2Plugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
+    
+    private static final String DRIVER_CLASS_NAME = "io.appium.java_client.android.AndroidDriver";
     
     static {
         Map<String, String> personalities = new HashMap<>();
@@ -41,6 +46,11 @@ public class UiAutomator2Plugin extends AbstractAppiumPlugin {
     @Override
     public Map<String, String> getPersonalities() {
         return PERSONALITIES;
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return DRIVER_CLASS_NAME;
     }
 
 }

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/WindowsPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/WindowsPlugin.java
@@ -15,15 +15,20 @@ public class WindowsPlugin extends AbstractAppiumPlugin {
     }
 
     private static final String CAPABILITIES =
-            "{\"automationName\":\"Windows\"," +
+            "{\"appium:automationName\":\"Windows\"," +
              "\"platformName\":\"Windows\"," +
              "\"maxInstances\":5}";
     
     private static final String BASELINE =
-            "{\"automationName\":\"Windows\"," + 
-             "\"platformName\":\"Windows\"}";
+            "{\"appium:automationName\":\"Windows\"," + 
+             "\"platformName\":\"Windows\"," +
+             "\"personality\":\"Windows\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.WindowsPlugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
+    
+    private static final String DRIVER_CLASS_NAME = "io.appium.java_client.windows.WindowsDriver";
     
     static {
         Map<String, String> personalities = new HashMap<>();
@@ -39,6 +44,11 @@ public class WindowsPlugin extends AbstractAppiumPlugin {
     @Override
     public Map<String, String> getPersonalities() {
         return PERSONALITIES;
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return DRIVER_CLASS_NAME;
     }
 
 }

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/XCUITestPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/XCUITestPlugin.java
@@ -15,17 +15,22 @@ public class XCUITestPlugin extends AbstractAppiumPlugin {
     }
 
     private static final String CAPABILITIES =
-            "{\"automationName\":\"XCUITest\"," +
+            "{\"appium:automationName\":\"XCUITest\"," +
              "\"platformName\":\"iOS\"," +
              "\"browserName\":\"Safari\"," +
              "\"maxInstances\":1," +
              "\"deviceName\":\"iPhone Simulator\"}";
     
     private static final String BASELINE =
-            "{\"automationName\":\"XCUITest\"," + 
-             "\"platformName\":\"iOS\"}";
+            "{\"appium:automationName\":\"XCUITest\"," + 
+             "\"platformName\":\"iOS\"," +
+             "\"personality\":\"XCUITest\"," +
+             "\"pluginClass\":\"com.nordstrom.automation.selenium.plugins.XCUITestPlugin\"" +
+            "}";
     
     private static final Map<String, String> PERSONALITIES;
+    
+    private static final String DRIVER_CLASS_NAME = "io.appium.java_client.ios.IOSDriver";
     
     static {
         Map<String, String> personalities = new HashMap<>();
@@ -41,6 +46,11 @@ public class XCUITestPlugin extends AbstractAppiumPlugin {
     @Override
     public Map<String, String> getPersonalities() {
         return PERSONALITIES;
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return DRIVER_CLASS_NAME;
     }
 
 }

--- a/src/main/java/com/nordstrom/automation/selenium/servlet/ExamplePageServlet.java
+++ b/src/main/java/com/nordstrom/automation/selenium/servlet/ExamplePageServlet.java
@@ -21,7 +21,6 @@ import com.nordstrom.automation.selenium.AbstractSeleniumConfig.SeleniumSettings
 public class ExamplePageServlet extends HttpServlet {
 
     private static final long serialVersionUID = -2195313096162880627L;
-    private static final String PATH = "/grid/admin";
 
     protected String pageSource;
     protected String target;
@@ -34,18 +33,6 @@ public class ExamplePageServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        
-        synchronized(pageSource) {
-            if (target == null) {
-                // convert relative servlet page references to absolute form
-                // NOTE: This works around a Selenium 2 Grid server issue.
-                String scheme = request.getScheme();
-                String host = request.getServerName();
-                int port = request.getServerPort();
-                target = scheme + "://" + host + ":" + port + PATH;
-                pageSource = pageSource.replaceAll(PATH, target);
-            }
-        }
         
         // Set response content type
         response.setContentType("text/html");

--- a/src/main/java/com/nordstrom/automation/selenium/support/SearchContextWait.java
+++ b/src/main/java/com/nordstrom/automation/selenium/support/SearchContextWait.java
@@ -1,7 +1,6 @@
 package com.nordstrom.automation.selenium.support;
 
-import java.util.concurrent.TimeUnit;
-
+import java.time.Duration;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
@@ -54,8 +53,8 @@ public class SearchContextWait extends FluentWait<SearchContext> {
      */
     public SearchContextWait(final SearchContext context, final long timeOutInSeconds, final long sleepInMillis) {
         super(context);
-        withTimeout(timeOutInSeconds, TimeUnit.SECONDS);
-        pollingEvery(sleepInMillis, TimeUnit.MILLISECONDS);
+        withTimeout(Duration.ofSeconds(timeOutInSeconds));
+        pollingEvery(Duration.ofMillis(sleepInMillis));
         ignoring(NotFoundException.class);
         this.context = context;
     }

--- a/src/main/java/com/nordstrom/automation/selenium/support/TestNgBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/support/TestNgBase.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriver;
 import org.testng.ITestNGListener;
 import org.testng.ITestResult;
 import org.testng.Reporter;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -211,6 +212,15 @@ public abstract class TestNgBase extends TestBase {
     @Override
     public boolean isAfterClass(final Method method) {
         return null != method.getAnnotation(AfterClass.class);
+    }
+    
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>NOTE</b>: This method throws a {@link SkipException} with the specified message.
+     */
+    public void skipTest(final String message) throws Exception {
+        throw new SkipException(message);
     }
     
     /**

--- a/src/main/java/com/nordstrom/automation/selenium/support/TestNgTargetBase.java
+++ b/src/main/java/com/nordstrom/automation/selenium/support/TestNgTargetBase.java
@@ -1,0 +1,16 @@
+package com.nordstrom.automation.selenium.support;
+
+import com.nordstrom.automation.selenium.platform.TargetType;
+
+public class TestNgTargetBase extends TestNgPlatformBase<TargetType> {
+
+    public TestNgTargetBase() {
+        super(TargetType.class);
+    }
+
+    @Override
+    public TargetType getDefaultPlatform() {
+        return TargetType.SUPPORT;
+    }
+
+}

--- a/src/selenium3/java/com/nordstrom/automation/selenium/utility/DataUtils.java
+++ b/src/selenium3/java/com/nordstrom/automation/selenium/utility/DataUtils.java
@@ -38,7 +38,7 @@ public final class DataUtils {
         try {
             return new Json().toType(json, type);
         } catch (JsonException e) {
-            LOGGER.debug("Failed to deserialize JSON object string: " + json, e);
+            LOGGER.debug("Failed to deserialize JSON object string: {}" + json, e.getMessage());
             return null;
         }
     }

--- a/src/test/java/com/nordstrom/automation/selenium/android/AndroidTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/android/AndroidTest.java
@@ -1,0 +1,35 @@
+package com.nordstrom.automation.selenium.android;
+
+import static com.nordstrom.automation.selenium.platform.TargetType.ANDROID_NAME;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.nordstrom.automation.selenium.annotations.InitialPage;
+import com.nordstrom.automation.selenium.examples.AndroidPage;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
+
+@InitialPage(AndroidPage.class)
+public class AndroidTest extends TestNgTargetRoot {
+    
+    private final String SEARCH_ACTIVITY = ".app.SearchInvoke";
+    private final String PACKAGE = "io.appium.android.apis";
+    
+//    private final String MY_PACKAGE = "com.example.myapplication";
+//    private final String SETTINGS_ACTIVITY = ".SettingsActivity";
+    
+//    private final String KEY_SIGNATURE = "signature";
+//    private final String KEY_REPLY = "reply";
+//    private final String KEY_SYNC = "sync";
+//    private final String KEY_ATTACHMENT = "attachment";
+    
+    @Test
+    @TargetPlatform(ANDROID_NAME)
+    public void foobar() {
+        AndroidPage page = getInitialPage();
+        page.submitSearchQuery("Hello world!");
+        Assert.assertEquals(page.getSearchResult(), "Hello world!");
+    }
+    
+}

--- a/src/test/java/com/nordstrom/automation/selenium/core/GridUtilityTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/core/GridUtilityTest.java
@@ -1,8 +1,9 @@
 package com.nordstrom.automation.selenium.core;
 
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -51,11 +52,16 @@ public class GridUtilityTest extends TestNgBase {
     @NoDriver
     public void testIsActive() throws IOException, InterruptedException, TimeoutException {
         SeleniumConfig config = SeleniumConfig.getConfig();
-        if (config.getHubUrl() != null) {
-            assertFalse(GridUtility.isHubActive(config.getHubUrl()), "Configured local hub should initially be inactive");
+        URL hubUrl = config.getHubUrl();
+        if (hubUrl != null) {
+            assertFalse(GridUtility.isHubActive(hubUrl), "Configured local hub should initially be inactive");
         }
-        config.getSeleniumGrid();
-        assertTrue(GridUtility.isHubActive(config.getHubUrl()), "Configured local hub should have been activated");
+        LocalSeleniumGrid localGrid = (LocalSeleniumGrid) config.getSeleniumGrid();
+        hubUrl = config.getHubUrl();
+        assertNotNull(hubUrl, "Configuration was not updated with local hub URL");
+        assertFalse(GridUtility.isHubActive(hubUrl), "Upon creation, local hub should be inactive");
+        localGrid.activate();
+        assertTrue(GridUtility.isHubActive(hubUrl), "Local hub should have been activated");
     }
     
     @NoDriver

--- a/src/test/java/com/nordstrom/automation/selenium/core/JsUtilityTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/core/JsUtilityTest.java
@@ -3,6 +3,7 @@ package com.nordstrom.automation.selenium.core;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -20,11 +21,12 @@ import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
 import com.nordstrom.automation.selenium.examples.ShadowRootComponent;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
 import com.nordstrom.automation.selenium.exceptions.ShadowRootContextException;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class JsUtilityTest extends TestNgRoot {
+public class JsUtilityTest extends TestNgTargetRoot {
 
     @NoDriver
     @Test(expectedExceptions = {AssertionError.class},
@@ -47,6 +49,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testRun() {
         ExamplePage page = getPage();
         String script = "document.querySelector(arguments[0]).value = arguments[1];";
@@ -55,6 +58,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testRunAndReturn() {
         ExamplePage page = getPage();
         page.setInputValue("test");
@@ -64,6 +68,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testInjectGlueLib() {
         ExamplePage page = getPage();
         WebDriver driver = page.getWrappedDriver();
@@ -74,6 +79,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testPropagate() {
         ExamplePage page = getPage();
         try {
@@ -85,6 +91,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRun() {
         try {
             ExamplePage page = getPage();
@@ -99,6 +106,7 @@ public class JsUtilityTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRunAndReturn() {
         try {
             ExamplePage page = getPage();

--- a/src/test/java/com/nordstrom/automation/selenium/core/WebDriverUtilsTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/core/WebDriverUtilsTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -25,15 +26,17 @@ import com.nordstrom.automation.selenium.SeleniumConfig;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
 import com.nordstrom.automation.selenium.model.RobustJavascriptExecutor;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class WebDriverUtilsTest extends TestNgRoot {
+public class WebDriverUtilsTest extends TestNgTargetRoot {
 
     @NoDriver
     @Test(expectedExceptions = {AssertionError.class},
             expectedExceptionsMessageRegExp = "WebDriverUtils is a static utility class that cannot be instantiated")
+    @TargetPlatform(WEB_APP_NAME)
     public void testPrivateConstructor() throws Throwable {
         
         Constructor<?>[] ctors;
@@ -52,6 +55,7 @@ public class WebDriverUtilsTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testGetDriver() {
         WebDriver driver = getDriver();
         ExamplePage page = getPage();
@@ -70,6 +74,7 @@ public class WebDriverUtilsTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testGetExecutor() {
         WebDriver driver = getDriver();
         ExamplePage page = getPage();
@@ -88,6 +93,7 @@ public class WebDriverUtilsTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testBrowserName() {
         WebDriver driver = getDriver();
         ExamplePage page = getPage();
@@ -108,6 +114,7 @@ public class WebDriverUtilsTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFilterHidden() {
         ExamplePage page = getPage();
         

--- a/src/test/java/com/nordstrom/automation/selenium/junit/JUnitModelTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/junit/JUnitModelTest.java
@@ -1,6 +1,7 @@
 package com.nordstrom.automation.selenium.junit;
 
 import static org.junit.Assume.assumeNoException;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -8,79 +9,92 @@ import org.junit.Test;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.core.ModelTestCore;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.JUnitRoot;
+import com.nordstrom.automation.selenium.examples.JUnitTargetRoot;
 import com.nordstrom.automation.selenium.exceptions.ShadowRootContextException;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class JUnitModelTest extends JUnitRoot {
+public class JUnitModelTest extends JUnitTargetRoot {
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testBasicPage() {
         ModelTestCore.testBasicPage(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testParagraphs() {
         ModelTestCore.testParagraphs(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testTable() {
         ModelTestCore.testTable(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByLocator() {
         ModelTestCore.testFrameByLocator(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByElement() {
         ModelTestCore.testFrameByElement(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByIndex() {
         ModelTestCore.testFrameByIndex(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameById() {
         ModelTestCore.testFrameById(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testComponentList() {
         ModelTestCore.testComponentList(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testComponentMap() {
         ModelTestCore.testComponentMap(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameList() {
         ModelTestCore.testFrameList(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameMap() {
         ModelTestCore.testFrameMap(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootByLocator() {
         try {
             ModelTestCore.testShadowRootByLocator(this).run();
@@ -91,6 +105,7 @@ public class JUnitModelTest extends JUnitRoot {
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootByElement() {
         try {
             ModelTestCore.testShadowRootByElement(this).run();
@@ -101,6 +116,7 @@ public class JUnitModelTest extends JUnitRoot {
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootList() {
         try {
             ModelTestCore.testShadowRootList(this).run();
@@ -111,6 +127,7 @@ public class JUnitModelTest extends JUnitRoot {
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootMap() {
         try {
             ModelTestCore.testShadowRootMap(this).run();
@@ -125,30 +142,35 @@ public class JUnitModelTest extends JUnitRoot {
      */
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testRefresh() {
         ModelTestCore.testRefresh(this);
     }
 
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testCssOptional() {
     	ModelTestCore.testCssOptional(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testXpathOptional() {
     	ModelTestCore.testXpathOptional(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testBogusOptional() {
     	ModelTestCore.testBogusOptional(this);
     }
     
     @Test
     @Ignore
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowParagraphs() {
         try {
             ModelTestCore.testShadowParagraphs(this).run();

--- a/src/test/java/com/nordstrom/automation/selenium/junit/JUnitPlatformTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/junit/JUnitPlatformTest.java
@@ -5,18 +5,15 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runners.model.FrameworkMethod;
-import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
 import com.nordstrom.automation.junit.AtomicTest;
 import com.nordstrom.automation.junit.LifecycleHooks;
-import com.nordstrom.automation.selenium.annotations.InitialPage;
-import com.nordstrom.automation.selenium.examples.ExamplePage;
+import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.exceptions.PlatformActivationFailedException;
 import com.nordstrom.automation.selenium.platform.Transition;
 import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
-@InitialPage(ExamplePage.class)
 public class JUnitPlatformTest extends JUnitPlatformBase<Transition> {
 
     public JUnitPlatformTest() {
@@ -24,12 +21,14 @@ public class JUnitPlatformTest extends JUnitPlatformBase<Transition> {
     }
     
     @Test
+    @NoDriver
     public void testDefaultPlatform() {
         assertTrue(getTargetPlatform().matches(Transition.PHASE1_NAME));
         assertEquals("green", getTargetPlatform().getColor());
     }
     
     @Test
+    @NoDriver
     @TargetPlatform(Transition.PHASE2_NAME)
     public void testPlatformTwo() {
         assertTrue(getTargetPlatform().matches(Transition.PHASE2_NAME));
@@ -60,7 +59,7 @@ public class JUnitPlatformTest extends JUnitPlatformBase<Transition> {
         }
         
         // perform some platform-related activation
-        driver.manage().addCookie(new Cookie("color", platform.getColor()));
+        System.setProperty("platform.phase.color", platform.getColor());
     }
 
     @Override

--- a/src/test/java/com/nordstrom/automation/selenium/junit/PageSourceCaptureTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/junit/PageSourceCaptureTest.java
@@ -2,6 +2,7 @@ package com.nordstrom.automation.selenium.junit;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.nio.file.Path;
 
@@ -10,13 +11,15 @@ import org.junit.Test;
 import com.google.common.base.Optional;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.JUnitRoot;
+import com.nordstrom.automation.selenium.examples.JUnitTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 import com.nordstrom.common.file.PathUtils;
 
 @InitialPage(ExamplePage.class)
-public class PageSourceCaptureTest extends JUnitRoot {
+public class PageSourceCaptureTest extends JUnitTargetRoot {
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testPageSourceCapture() {
         PageSourceCapture collector = pageSourceCapture;
         assumeTrue(collector.getArtifactProvider().canGetArtifact(this));

--- a/src/test/java/com/nordstrom/automation/selenium/junit/ScreenshotCaptureTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/junit/ScreenshotCaptureTest.java
@@ -2,6 +2,7 @@ package com.nordstrom.automation.selenium.junit;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.nio.file.Path;
 
@@ -9,13 +10,15 @@ import org.junit.Test;
 import com.google.common.base.Optional;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.JUnitRoot;
+import com.nordstrom.automation.selenium.examples.JUnitTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 import com.nordstrom.common.file.PathUtils;
 
 @InitialPage(ExamplePage.class)
-public class ScreenshotCaptureTest extends JUnitRoot {
+public class ScreenshotCaptureTest extends JUnitTargetRoot {
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testScreenshotCapture() {
         ScreenshotCapture collector = screenshotCapture;
         assumeTrue(collector.getArtifactProvider().canGetArtifact(this));

--- a/src/test/java/com/nordstrom/automation/selenium/listeners/DriverManagerTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/listeners/DriverManagerTest.java
@@ -2,6 +2,7 @@ package com.nordstrom.automation.selenium.listeners;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -9,9 +10,10 @@ import org.testng.annotations.Test;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.annotations.PageUrl;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
-public class DriverManagerTest extends TestNgRoot {
+public class DriverManagerTest extends TestNgTargetRoot {
     
     @BeforeMethod(groups = {"WithDriverBefore"})
     @InitialPage(pageUrl=@PageUrl("/grid/admin/ExamplePageServlet"))
@@ -20,12 +22,14 @@ public class DriverManagerTest extends TestNgRoot {
     }
     
     @Test(groups = {"WithDriverBefore"})
+    @TargetPlatform(WEB_APP_NAME)
     public void testWithDriverBefore() {
         assertTrue(nabDriver().isPresent(), "Driver should have been created");
     }
     
     @NoDriver
     @Test(groups = {"WithDriverBefore"})
+    @TargetPlatform(WEB_APP_NAME)
     public void testCloseDriverBefore() {
         assertFalse(nabDriver().isPresent(), "Driver should have been closed");
     }

--- a/src/test/java/com/nordstrom/automation/selenium/listeners/NoDriverManagerTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/listeners/NoDriverManagerTest.java
@@ -2,15 +2,17 @@ package com.nordstrom.automation.selenium.listeners;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.exceptions.DriverNotAvailableException;
-import com.nordstrom.automation.selenium.support.TestNgBase;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
+import com.nordstrom.automation.selenium.support.TestNgTargetBase;
 
-public class NoDriverManagerTest extends TestNgBase {
+public class NoDriverManagerTest extends TestNgTargetBase {
 
     @BeforeMethod(groups = {"NoDriverBefore"})
     public void beforeMethodNoDriver() {
@@ -19,17 +21,20 @@ public class NoDriverManagerTest extends TestNgBase {
     
     @NoDriver
     @Test(groups = {"NoBeforeNoDriver"})
+    @TargetPlatform(WEB_APP_NAME)
     public void testNoBeforeNoDriver() {
         assertFalse(nabDriver().isPresent(), "Driver should not have been created");
     }
     
     @Test(groups = {"NoDriverBefore"})
+    @TargetPlatform(WEB_APP_NAME)
     public void testNoDriverBefore() {
         assertTrue(nabDriver().isPresent(), "Driver should have been created");
     }
     
     @NoDriver
     @Test(groups = {"NoBeforeNoDriver"}, expectedExceptions = {DriverNotAvailableException.class})
+    @TargetPlatform(WEB_APP_NAME)
     public void testNoDriverException() {
         getDriver();
     }

--- a/src/test/java/com/nordstrom/automation/selenium/listeners/PageSourceCaptureTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/listeners/PageSourceCaptureTest.java
@@ -1,6 +1,7 @@
 package com.nordstrom.automation.selenium.listeners;
 
 import static org.testng.Assert.assertTrue;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.nio.file.Path;
 
@@ -11,12 +12,14 @@ import org.testng.annotations.Test;
 import com.google.common.base.Optional;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class PageSourceCaptureTest extends TestNgRoot {
+public class PageSourceCaptureTest extends TestNgTargetRoot {
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testPageSourceCapture() {
         PageSourceCapture collector = getLinkedListener(PageSourceCapture.class);
         if (collector.getArtifactProvider().canGetArtifact(Reporter.getCurrentTestResult())) {

--- a/src/test/java/com/nordstrom/automation/selenium/listeners/ScreenshotCaptureTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/listeners/ScreenshotCaptureTest.java
@@ -1,6 +1,7 @@
 package com.nordstrom.automation.selenium.listeners;
 
 import static org.testng.Assert.assertTrue;
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
 
 import java.nio.file.Path;
 
@@ -11,12 +12,14 @@ import org.testng.annotations.Test;
 import com.google.common.base.Optional;
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class ScreenshotCaptureTest extends TestNgRoot {
+public class ScreenshotCaptureTest extends TestNgTargetRoot {
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testScreenshotCapture() {
         ScreenshotCapture collector = getLinkedListener(ScreenshotCapture.class);
         if (collector.getArtifactProvider().canGetArtifact(Reporter.getCurrentTestResult())) {

--- a/src/test/java/com/nordstrom/automation/selenium/model/ModelTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/model/ModelTest.java
@@ -1,73 +1,88 @@
 package com.nordstrom.automation.selenium.model;
 
+import static com.nordstrom.automation.selenium.platform.TargetType.WEB_APP_NAME;
+
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.core.ModelTestCore;
 import com.nordstrom.automation.selenium.examples.ExamplePage;
-import com.nordstrom.automation.selenium.examples.TestNgRoot;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
 import com.nordstrom.automation.selenium.exceptions.ShadowRootContextException;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
 @InitialPage(ExamplePage.class)
-public class ModelTest extends TestNgRoot {
+public class ModelTest extends TestNgTargetRoot {
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testBasicPage() {
         ModelTestCore.testBasicPage(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testParagraphs() {
         ModelTestCore.testParagraphs(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testTable() {
         ModelTestCore.testTable(this);
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByLocator() {
         ModelTestCore.testFrameByLocator(this);
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByElement() {
         ModelTestCore.testFrameByElement(this);
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameByIndex() {
         ModelTestCore.testFrameByIndex(this);
     }
 
     @Test(enabled = false)
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameById() {
         ModelTestCore.testFrameById(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testComponentList() {
         ModelTestCore.testComponentList(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testComponentMap() {
         ModelTestCore.testComponentMap(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameList() {
         ModelTestCore.testFrameList(this);
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testFrameMap() {
         ModelTestCore.testFrameMap(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootByLocator() {
         try {
             ModelTestCore.testShadowRootByLocator(this).run();
@@ -77,6 +92,7 @@ public class ModelTest extends TestNgRoot {
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootByElement() {
         try {
             ModelTestCore.testShadowRootByElement(this).run();
@@ -86,6 +102,7 @@ public class ModelTest extends TestNgRoot {
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootList() {
         try {
             ModelTestCore.testShadowRootList(this).run();
@@ -95,6 +112,7 @@ public class ModelTest extends TestNgRoot {
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowRootMap() {
         try {
             ModelTestCore.testShadowRootMap(this).run();
@@ -108,26 +126,31 @@ public class ModelTest extends TestNgRoot {
      * and that the search context chain gets refreshed efficiently.
      */
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testRefresh() {
         ModelTestCore.testRefresh(this);
     }
 
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testCssOptional() {
     	ModelTestCore.testCssOptional(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testXpathOptional() {
     	ModelTestCore.testXpathOptional(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testBogusOptional() {
     	ModelTestCore.testBogusOptional(this);
     }
     
     @Test
+    @TargetPlatform(WEB_APP_NAME)
     public void testShadowParagraphs() {
         try {
             ModelTestCore.testShadowParagraphs(this).run();

--- a/src/test/java/com/nordstrom/automation/selenium/support/TestNgPlatformTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/support/TestNgPlatformTest.java
@@ -3,20 +3,17 @@ package com.nordstrom.automation.selenium.support;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Reporter;
 import org.testng.annotations.Test;
 
-import com.nordstrom.automation.selenium.annotations.InitialPage;
-import com.nordstrom.automation.selenium.examples.ExamplePage;
+import com.nordstrom.automation.selenium.annotations.NoDriver;
 import com.nordstrom.automation.selenium.exceptions.PlatformActivationFailedException;
 import com.nordstrom.automation.selenium.platform.Transition;
 import com.nordstrom.automation.selenium.platform.TargetPlatform;
 
-@InitialPage(ExamplePage.class)
 public class TestNgPlatformTest extends TestNgPlatformBase<Transition> {
 
     public TestNgPlatformTest() {
@@ -24,12 +21,14 @@ public class TestNgPlatformTest extends TestNgPlatformBase<Transition> {
     }
     
     @Test
+    @NoDriver
     public void testDefaultPlatform() {
         assertTrue(getTargetPlatform().matches(Transition.PHASE1_NAME));
         assertEquals(getTargetPlatform().getColor(), "green");
     }
     
     @Test
+    @NoDriver
     @TargetPlatform(Transition.PHASE2_NAME)
     public void testPlatformTwo() {
         assertTrue(getTargetPlatform().matches(Transition.PHASE2_NAME));
@@ -60,7 +59,7 @@ public class TestNgPlatformTest extends TestNgPlatformBase<Transition> {
         }
         
         // perform some platform-related activation
-        driver.manage().addCookie(new Cookie("color", platform.getColor()));
+        System.setProperty("platform.phase.color", platform.getColor());
     }
 
     @Override


### PR DESCRIPTION
Resolves #225 and #227

* I revised the instantiation behavior of **Local Grid** instances to separate the creation of the hub/node model from the launch of the associated Grid servers. These revisions included renaming existing methods (**`start`**/**`launch`** &rarr; **`create`**), adding a new **`activate`** method to activate the local Grid instance, and adding a new **`start`** method that's solely focused on starting the local Grid server processes, ensuring that the servers are active and registered.
* The "personality" records returned by driver plug-ins now specify the class of the plug-in with which they're associated.
* I tweaked the behavior of the **`AbstractSeleniumConfig.getModifications`** method to ensure that **Capabilities** for Grid nodes and driver requests will always specify "personality".
* Prior to instantiating a driver, I ensure that the local Grid is activated. I also remove the "personality" and "pluginClass" capabilities from the request, which are proprietary and will be rejected by strict W3C-compliant providers.
* These revisions enabled me to modify the implementation of the **target platform** feature to avoid launching a Grid or instantiating a driver if the tests associated with the active platforms don't need them.
* To enable instantiation of drivers by plug-ins that require target-specific drivers (e.g. - **AndroidDriver**), I added a new method to the **DriverPlugin** interface that returns a constructor for the associated driver class.
* I revised the definition and realization of the `@PageUrl` annotation to add support for Android application "activities".
* I implemented and applied a platform set for the unit tests. This enabled me to implement a test class and page model for the first Android application unit test. Existing web application unit test classes have been revised to extend the new **TestNgTargetRoot** and **JUnitTargetRoot** classes, adding corresponding **`@TargetPlatform`** annotations to existing test methods,
* I wrapped calls to commands that aren't supported by **Appium** drivers to catch **UnsupportedCommandException**.
* I tweaked the code that locates the **Appium** main script to ignore potential preamble (info and warning messages).
* I updated a few deprecated references to the **TimeUnit** class to their **Duration** class equivalents.
* I added a **`skipTest`** method to the **TestBase** class to provide a framework-agnostic mechanism for aborting a test.
* I removed a few explicit class references to static methods within the same class.
* I pared down the debug message posted by **`DataUtils.fromString`** to omit the exception stack frames.
* I removed workaround code in the **ExamplePageServlet** class for a Selenium 2 Grid issue.
* I updated **`GridUtilityTest.testIsActive`** to work with the new activation behavior of local Grid instances.
* I also removed a couple of deprecated methods and references to the Selenium 2 API in documentation and code comments.