### PR TITLE
Add Windows page/test; catch WebDriverException

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 profile=selenium3
-version=26.1.2-SNAPSHOT
+version=26.2.0-SNAPSHOT
 org.gradle.java.installations.auto-detect=false
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.fromEnv=JDK8_HOME,JDK11_HOME

--- a/src/main/java/com/nordstrom/automation/selenium/core/DriverManager.java
+++ b/src/main/java/com/nordstrom/automation/selenium/core/DriverManager.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.Timeouts;
 import org.openqa.selenium.WebDriverException;
@@ -185,7 +184,7 @@ public final class DriverManager {
         
         try {
             timeouts.pageLoadTimeout(WaitType.PAGE_LOAD.getInterval(config), TimeUnit.SECONDS);
-        } catch (UnsupportedCommandException e) {
+        } catch (WebDriverException e) {
             // unsupported feature: nothing to do here
         }
     }

--- a/src/main/java/com/nordstrom/automation/selenium/examples/WindowsPage.java
+++ b/src/main/java/com/nordstrom/automation/selenium/examples/WindowsPage.java
@@ -1,0 +1,36 @@
+package com.nordstrom.automation.selenium.examples;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import com.nordstrom.automation.selenium.model.Page;
+
+public class WindowsPage extends Page {
+
+    public WindowsPage(WebDriver driver) {
+        super(driver);
+    }
+    
+    protected enum Using implements ByEnum {
+        EDIT_FIELD(By.className("Edit"));
+        
+        private By locator;
+        
+        Using(By locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public By locator() {
+            return locator;
+        }
+    }
+    
+    public void modifyDocument(String keys) {
+        findElement(Using.EDIT_FIELD).sendKeys(keys);
+    }
+    
+    public String getDocument() {
+        return findElement(Using.EDIT_FIELD).getText();
+    }
+    
+}

--- a/src/main/java/com/nordstrom/automation/selenium/model/Page.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/Page.java
@@ -2,6 +2,7 @@ package com.nordstrom.automation.selenium.model;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.openqa.selenium.SearchContext;
@@ -9,7 +10,6 @@ import org.openqa.selenium.WebDriver;
 
 import com.nordstrom.automation.selenium.annotations.InitialPage;
 import com.nordstrom.automation.selenium.annotations.PageUrl;
-import com.nordstrom.automation.selenium.exceptions.InitialPageNotSpecifiedException;
 
 /**
  * Extend this class when modeling a browser page.
@@ -171,12 +171,11 @@ public class Page extends ComponentContainer {
     public static <T extends Page> T openInitialPage(
                     final InitialPage initialPage, final WebDriver driver, final URI targetUri) {
         
+        Objects.requireNonNull(initialPage, "[initialPage] must be non-null");
         String url = getInitialUrl(initialPage, targetUri);
-        if (url == null) {
-            throw new InitialPageNotSpecifiedException();
+        if (url != null) {
+            getUrl(url, driver);
         }
-        
-        getUrl(url, driver);
         return newPage((Class<T>) initialPage.value(), driver);
     }
     

--- a/src/test/java/com/nordstrom/automation/selenium/windows/WindowsTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/windows/WindowsTest.java
@@ -1,0 +1,26 @@
+package com.nordstrom.automation.selenium.windows;
+
+import static com.nordstrom.automation.selenium.platform.TargetType.WINDOWS_NAME;
+import static org.testng.Assert.assertEquals;
+
+import org.openqa.selenium.Keys;
+import org.testng.annotations.Test;
+
+import com.nordstrom.automation.selenium.examples.WindowsPage;
+import com.nordstrom.automation.selenium.annotations.InitialPage;
+import com.nordstrom.automation.selenium.examples.TestNgTargetRoot;
+import com.nordstrom.automation.selenium.platform.TargetPlatform;
+
+@InitialPage(WindowsPage.class)
+public class WindowsTest extends TestNgTargetRoot {
+    
+    @Test
+    @TargetPlatform(WINDOWS_NAME)
+    public void testEditing() {
+        WindowsPage page = getInitialPage();
+        page.modifyDocument("Hello world!");
+        assertEquals(page.getDocument(), "Hello world!");
+        page.modifyDocument(Keys.CONTROL + "z");
+    }
+    
+}


### PR DESCRIPTION
This PR finished up the implementation of **WindowsPlugin**. It includes a couple of tweaks to account for the response to an unsupported method and the fact that there's no direct navigation with the Windows automation engine.