### PR TITLE
Start all servers, then wait for active/register

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <guava.version>31.1-jre</guava.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <jsoup.version>1.15.1</jsoup.version>
-        <htmlunit.version>2.63.0</htmlunit.version>
+        <htmlunit.version>2.64.0</htmlunit.version>
         <jcommander.version>1.82</jcommander.version>
         <mockito.version>4.6.1</mockito.version>
         <!-- managed to resolve identified threat -->

--- a/selenium3Deps.gradle
+++ b/selenium3Deps.gradle
@@ -37,7 +37,7 @@ dependencies {
     api 'org.eclipse.jetty.websocket:websocket-client:9.4.46.v20220331'
     api 'org.jetbrains.kotlin:kotlin-stdlib:1.7.0'
     api 'org.jetbrains.kotlin:kotlin-stdlib-common:1.7.0'
-    testImplementation 'org.seleniumhq.selenium:htmlunit-driver:2.63.0'
+    testImplementation 'org.seleniumhq.selenium:htmlunit-driver:2.64.0'
     testImplementation 'org.mockito:mockito-core:4.6.1'
   }
   api 'com.nordstrom.tools:testng-foundation'

--- a/src/main/java/com/nordstrom/automation/selenium/core/GridUtility.java
+++ b/src/main/java/com/nordstrom/automation/selenium/core/GridUtility.java
@@ -65,13 +65,32 @@ public final class GridUtility {
     }
     
     /**
-     * Determine if the configured Selenium Grid hub is active.
+     * Determine if the specified Selenium Grid hub is active.
      * 
      * @param hubUrl {@link URL} to be checked
-     * @return 'true' if configured hub is active; otherwise 'false'
+     * @return 'true' if specified hub is active; otherwise 'false'
      */
     public static boolean isHubActive(URL hubUrl) {
         return isHostActive(hubUrl, GridServer.HUB_CONFIG);
+    }
+    
+    /**
+     * Determine if the indicated Selenium Grid node is registered with the specified hub.
+     * 
+     * @param config {@link SeleniumConfig} object
+     * @param hubUrl {@link URL} of hub to query
+     * @param nodeUrl {@link URL} of node in question
+     * @return 'true' if indicated node is registered; otherwise 'false'
+     */
+    public static boolean isNodeRegistered(SeleniumConfig config, URL hubUrl, URL nodeUrl) {
+        try {
+            String nodeEndpoint = nodeUrl.getProtocol() + "://" + nodeUrl.getAuthority();
+            Capabilities capabilities = getNodeCapabilities(config, hubUrl, nodeEndpoint);
+            return capabilities.is("success");
+        } catch (IOException eaten) {
+            // nothing to do here
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/nordstrom/automation/selenium/model/Enhanceable.java
+++ b/src/main/java/com/nordstrom/automation/selenium/model/Enhanceable.java
@@ -18,8 +18,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasMethodName;
-import static net.bytebuddy.matcher.ElementMatchers.hasSignature;
-import static net.bytebuddy.matcher.ElementMatchers.is;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
@@ -100,18 +99,13 @@ public abstract class Enhanceable<T> {
                     if (bypassClass.isInterface()) {
                         // iterate over interface methods
                         for (Method method : bypassClass.getMethods()) {
-                            // match this method's signature
-                            matcher = matcher.or(
-                                    hasSignature(new MethodDescription.ForLoadedMethod(method)
-                                            .asSignatureToken()));
+                            // match this method's name
+                            matcher = matcher.or(hasMethodName(method.getName()));
                         }
                     // otherwise (bypassing a class)
                     } else {
-                        // iterate over class methods
-                        for (Method method : bypassClass.getMethods()) {
-                            // match this method exactly
-                            matcher = matcher.or(is(method));
-                        }
+                        // match any method declared by this class
+                        matcher = matcher.or(isDeclaredBy(bypassClass));
                     }
                 }
                 

--- a/src/test/java/com/nordstrom/automation/selenium/core/ModelTestCore.java
+++ b/src/test/java/com/nordstrom/automation/selenium/core/ModelTestCore.java
@@ -15,6 +15,7 @@ import com.nordstrom.automation.selenium.examples.ExamplePage;
 import com.nordstrom.automation.selenium.examples.FrameComponent;
 import com.nordstrom.automation.selenium.examples.ShadowRootComponent;
 import com.nordstrom.automation.selenium.examples.TableComponent;
+import com.nordstrom.automation.selenium.model.Enhanced;
 
 @InitialPage(ExamplePage.class)
 public class ModelTestCore {
@@ -22,6 +23,7 @@ public class ModelTestCore {
     public static void testBasicPage(TestBase instance) {
         ExamplePage page = instance.getInitialPage();
         assertEquals(page.getTitle(), TITLE);
+        assertTrue(page instanceof Enhanced);
     }
     
     public static void testParagraphs(TestBase instance) {
@@ -49,30 +51,35 @@ public class ModelTestCore {
         assertArrayEquals(content.get(0).toArray(), CONTENT[0]);
         assertArrayEquals(content.get(1).toArray(), CONTENT[1]);
         assertArrayEquals(content.get(2).toArray(), CONTENT[2]);
+        assertTrue(component instanceof Enhanced);
     }
     
     public static void testFrameByLocator(TestBase instance) {
         ExamplePage page = instance.getInitialPage();
         FrameComponent component = page.getFrameByLocator();
         assertEquals(component.getPageContent(), FRAME_A);
+        assertTrue(component instanceof Enhanced);
     }
     
     public static void testFrameByElement(TestBase instance) {
         ExamplePage page = instance.getInitialPage();
         FrameComponent component = page.getFrameByElement();
         assertEquals(component.getPageContent(), FRAME_B);
+        assertTrue(component instanceof Enhanced);
     }
     
     public static void testFrameByIndex(TestBase instance) {
         ExamplePage page = instance.getInitialPage();
         FrameComponent component = page.getFrameByIndex();
         assertEquals(component.getPageContent(), FRAME_C);
+        assertTrue(component instanceof Enhanced);
     }
     
     public static void testFrameById(TestBase instance) {
         ExamplePage page = instance.getInitialPage();
         FrameComponent component = page.getFrameById();
         assertEquals(component.getPageContent(), FRAME_D);
+        assertTrue(component instanceof Enhanced);
     }
     
     public static void testComponentList(TestBase instance) {
@@ -92,9 +99,13 @@ public class ModelTestCore {
         List<FrameComponent> frameList = page.getFrameList();
         assertEquals(frameList.size(), 4);
         assertEquals(frameList.get(0).getPageContent(), FRAME_A);
+        assertTrue(frameList.get(0) instanceof Enhanced);
         assertEquals(frameList.get(1).getPageContent(), FRAME_B);
+        assertTrue(frameList.get(1) instanceof Enhanced);
         assertEquals(frameList.get(2).getPageContent(), FRAME_C);
+        assertTrue(frameList.get(2) instanceof Enhanced);
         assertEquals(frameList.get(3).getPageContent(), FRAME_D);
+        assertTrue(frameList.get(3) instanceof Enhanced);
     }
     
     public static void testFrameMap(TestBase instance) {
@@ -102,9 +113,13 @@ public class ModelTestCore {
         Map<Object, FrameComponent> frameMap = page.getFrameMap();
         assertEquals(frameMap.size(), 4);
         assertEquals(frameMap.get(FRAME_A).getPageContent(), FRAME_A);
+        assertTrue(frameMap.get(FRAME_A) instanceof Enhanced);
         assertEquals(frameMap.get(FRAME_B).getPageContent(), FRAME_B);
+        assertTrue(frameMap.get(FRAME_B) instanceof Enhanced);
         assertEquals(frameMap.get(FRAME_C).getPageContent(), FRAME_C);
+        assertTrue(frameMap.get(FRAME_C) instanceof Enhanced);
         assertEquals(frameMap.get(FRAME_D).getPageContent(), FRAME_D);
+        assertTrue(frameMap.get(FRAME_D) instanceof Enhanced);
     }
     
     public static Runnable testShadowRootByLocator(final TestBase instance) {
@@ -115,6 +130,7 @@ public class ModelTestCore {
             public void run() {
                 ShadowRootComponent shadowRoot = page.getShadowRootByLocator();
                 assertEquals(shadowRoot.getHeading(), SHADOW_DOM_A);
+                assertTrue(shadowRoot instanceof Enhanced);
             }
         };
     }
@@ -127,6 +143,7 @@ public class ModelTestCore {
             public void run() {
                 ShadowRootComponent shadowRoot = page.getShadowRootByElement();
                 assertEquals(shadowRoot.getHeading(), SHADOW_DOM_B);
+                assertTrue(shadowRoot instanceof Enhanced);
             }
         };
     }
@@ -140,7 +157,9 @@ public class ModelTestCore {
                 List<ShadowRootComponent> shadowRootList = page.getShadowRootList();
                 assertEquals(shadowRootList.size(), 2);
                 assertEquals(shadowRootList.get(0).getHeading(), SHADOW_DOM_A);
+                assertTrue(shadowRootList.get(0) instanceof Enhanced);
                 assertEquals(shadowRootList.get(1).getHeading(), SHADOW_DOM_B);
+                assertTrue(shadowRootList.get(1) instanceof Enhanced);
             }
         };
     }
@@ -154,7 +173,9 @@ public class ModelTestCore {
                 Map<Object, ShadowRootComponent> shadowRootMap = page.getShadowRootMap();
                 assertEquals(shadowRootMap.size(), 2);
                 assertEquals(shadowRootMap.get(SHADOW_DOM_A).getHeading(), SHADOW_DOM_A);
+                assertTrue(shadowRootMap.get(SHADOW_DOM_A) instanceof Enhanced);
                 assertEquals(shadowRootMap.get(SHADOW_DOM_B).getHeading(), SHADOW_DOM_B);
+                assertTrue(shadowRootMap.get(SHADOW_DOM_B) instanceof Enhanced);
             }
         };
     }


### PR DESCRIPTION
In addition to revising the Grid collection launch strategy, I also fixed a problem with "enhanced" objects that caused interface methods that should be skipped to get intercepted. 